### PR TITLE
Update pc.yaml

### DIFF
--- a/packages/pc.yaml
+++ b/packages/pc.yaml
@@ -861,7 +861,7 @@ automation:
           {% elif states(states('input_text.carico_16_switch')) == 'on' and states('input_number.potenza_16_sospesa')|int(default=0) > 0 %}input_number.potenza_16_sospesa
           {% elif states(states('input_text.carico_17_switch')) == 'on' and states('input_number.potenza_17_sospesa')|int(default=0) > 0 %}input_number.potenza_17_sospesa
           {% elif states(states('input_text.carico_18_switch')) == 'on' and states('input_number.potenza_18_sospesa')|int(default=0) > 0 %}input_number.potenza_18_sospesa
-          {% elif states(states('input_text.carico_19_switch')) == 'on' and states('input_number.potenza_19_sospesa')|int(default=0) > 0 %}input_number.potenza_11_sospesa
+          {% elif states(states('input_text.carico_19_switch')) == 'on' and states('input_number.potenza_19_sospesa')|int(default=0) > 0 %}input_number.potenza_19_sospesa
           {% elif states(states('input_text.carico_20_switch')) == 'on' and states('input_number.potenza_20_sospesa')|int(default=0) > 0 %}input_number.potenza_20_sospesa
           {% else %}none
           {% endif %}"


### PR DESCRIPTION
In the watchdog automation that monitors manual device activation, there is a copy-paste error for Load #19. If you manually turn on device #19, it resets the "suspended power" memory for device #11 instead of #19.
  Why: This will prevent the system from correctly calculating available power for device #11 and will leave device #19's state inconsistent in the power manager.