### PR TITLE
fix: replace deprecated async_track_state_change with async_track_state_change_event

### DIFF
--- a/custom_components/power_control/coordinator.py
+++ b/custom_components/power_control/coordinator.py
@@ -14,8 +14,19 @@ from homeassistant.helpers import entity_registry as er
 try:
     from homeassistant.helpers.event import async_track_state_change_event
 except ImportError:
-    async_track_state_change_event = None
-from homeassistant.helpers.event import async_track_state_change
+    from homeassistant.helpers.event import async_track_state_change as _legacy
+
+    class _LegacyEvent:
+        def __init__(self, entity_id, old_state, new_state):
+            self.data = {"entity_id": entity_id, "old_state": old_state, "new_state": new_state}
+
+    def async_track_state_change_event(hass, entity_ids, action):
+        @callback
+        def _wrap(entity_id, old_state, new_state):
+            action(_LegacyEvent(entity_id, old_state, new_state))
+
+        return _legacy(hass, entity_ids, _wrap)
+
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .notify import async_notify
@@ -185,24 +196,17 @@ class PowerControlCoordinator(DataUpdateCoordinator[PowerControlData]):
             )
             self.hass.async_create_task(self.async_request_refresh())
 
-        if async_track_state_change_event:
-            @callback
-            def _on_sensor_change_event(event):
-                _on_sensor_change(
-                    event.data["entity_id"],
-                    event.data.get("old_state"),
-                    event.data.get("new_state"),
-                )
+        @callback
+        def _on_sensor_change_event(event):
+            _on_sensor_change(
+                event.data["entity_id"],
+                event.data.get("old_state"),
+                event.data.get("new_state"),
+            )
 
-            self._global_sensor_unsub = async_track_state_change_event(
-                self.hass, global_sensor, _on_sensor_change_event
-            )
-        else:
-            self._global_sensor_unsub = async_track_state_change(
-                self.hass,
-                global_sensor,
-                _on_sensor_change,
-            )
+        self._global_sensor_unsub = async_track_state_change_event(
+            self.hass, global_sensor, _on_sensor_change_event
+        )
 
         _LOGGER.debug(
             "[%s] Registered state-change listener on %s", DOMAIN, global_sensor

--- a/custom_components/power_control/coordinator.py
+++ b/custom_components/power_control/coordinator.py
@@ -11,6 +11,10 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import entity_registry as er
+try:
+    from homeassistant.helpers.event import async_track_state_change_event
+except ImportError:
+    async_track_state_change_event = None
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -181,11 +185,24 @@ class PowerControlCoordinator(DataUpdateCoordinator[PowerControlData]):
             )
             self.hass.async_create_task(self.async_request_refresh())
 
-        self._global_sensor_unsub = async_track_state_change(
-            self.hass,
-            global_sensor,
-            _on_sensor_change,
-        )
+        if async_track_state_change_event:
+            @callback
+            def _on_sensor_change_event(event):
+                _on_sensor_change(
+                    event.data["entity_id"],
+                    event.data.get("old_state"),
+                    event.data.get("new_state"),
+                )
+
+            self._global_sensor_unsub = async_track_state_change_event(
+                self.hass, global_sensor, _on_sensor_change_event
+            )
+        else:
+            self._global_sensor_unsub = async_track_state_change(
+                self.hass,
+                global_sensor,
+                _on_sensor_change,
+            )
 
         _LOGGER.debug(
             "[%s] Registered state-change listener on %s", DOMAIN, global_sensor


### PR DESCRIPTION
Async_track_state_change was deprecated in HA 2025.5 and scheduled for removal. This fix uses async_track_state_change_event on supported HA versions while falling back to the old function on older instances.

Adds a try/except import for forward compatibility and an event adapter wrapper that extracts entity_id/old_state/new_state from the Event object to reuse the existing callback logic unchanged.